### PR TITLE
Solves the notice in Magento 2 system log for Settings helper.

### DIFF
--- a/Helper/Settings.php
+++ b/Helper/Settings.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * This module makes it possible to upload different filetypes inside the WYSIWYG-editor. Extra filetypes are Word (doc, docm, docx), Excel (csv, xml, xls, xlsx), PDF (pdf), Compressed Folder (zip, tar)
- * Copyright (C) 2016  
- * 
+ * Copyright (C) 2016
+ *
  * This file included in Experius/WysiwygDownloads is licensed under OSL 3.0
- * 
+ *
  * http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  * Please see LICENSE.txt for the full text of the OSL 3.0 license
  */
- 
+
 namespace Experius\WysiwygDownloads\Helper;
 
 use Magento\Framework\App\Helper\Context;
@@ -20,19 +20,19 @@ class Settings extends \Magento\Framework\App\Helper\AbstractHelper
 {
 
 	const CONFIG_PATH_FILETYPES = 'wysiwyg/filetypes';
-    
+
     public $configPathModule = 'cms';
-    
+
     protected $_storeManager;
-    
+
     /**
      * Currently selected store ID if applicable
      *
      * @var int
      */
     protected $_storeId;
-    
-    
+
+
     public function __construct(
         Context $context,
         \Magento\Store\Model\StoreManagerInterface $storeManager
@@ -41,7 +41,7 @@ class Settings extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_storeManager = $storeManager;
         parent::__construct($context);
     }
-    
+
     /**
      * Set a specified store ID value
      *
@@ -55,7 +55,7 @@ class Settings extends \Magento\Framework\App\Helper\AbstractHelper
         }
         return $this->_storeId;
     }
-    
+
     /**
      * Set a specified store ID value
      *
@@ -67,7 +67,7 @@ class Settings extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_storeId = $store;
         return $this;
     }
-    
+
     public function getConfigValue($path)
     {
         if (substr_count($path, '/') < 2){
@@ -79,18 +79,18 @@ class Settings extends \Magento\Framework\App\Helper\AbstractHelper
             $this->getStoreId()
         );
     }
-    
+
 	public function getExtraFiletypes()
 	{
-    	$filetypes = array();
-        $settings = unserialize($this->getConfigValue(self::CONFIG_PATH_FILETYPES));
-        if ($settings) {
-            foreach($settings as $setting){
-                $filetypes[] =  $setting['extension'];
-            }
-        }
-		$defaultFiletypes = array('doc','docm','docx','csv','xml','xls','xlsx','pdf','zip','tar');
-		return array_merge($filetypes,$defaultFiletypes);
+      $filetypes = array();
+      $settings = json_decode($this->getConfigValue(self::CONFIG_PATH_FILETYPES));
+      if ($settings) {
+          foreach($settings as $setting){
+              $filetypes[] =  $setting->extension;
+          }
+      }
+      $defaultFiletypes = array('doc','docm','docx','csv','xml','xls','xlsx','pdf','zip','tar');
+      return array_merge($filetypes,$defaultFiletypes);
 	}
-   
+
 }


### PR DESCRIPTION
Full error from Magento 2:
Notice: unserialize(): Error at offset 0 in vendor/experius/module-wysiwygdownloads/Helper/Settings.php on line 86.