### PR TITLE
Fix upload issue in 2.2.5 by adding file and mime types

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -2,6 +2,58 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 	<type name="Magento\Cms\Model\Wysiwyg\Images\Storage">
 		<plugin disabled="false" name="Experius_WysiwygDownloads_Plugin_Magento_Cms_Model_Wysiwyg_Images_Storage" sortOrder="10" type="Experius\WysiwygDownloads\Plugin\Magento\Cms\Model\Wysiwyg\Images\Storage"/>
+        <arguments>
+            <argument name="extensions" xsi:type="array">
+                <item name="allowed" xsi:type="array">
+                    <item name="jpg" xsi:type="string">image/jpg</item>
+                    <item name="jpeg" xsi:type="string">image/jpeg</item>
+                    <item name="png" xsi:type="string">image/png</item>
+                    <item name="gif" xsi:type="string">image/gif</item>
+                    <item name="pdf" xsi:type="string">application/pdf</item>
+                    <item name="doc" xsi:type="string">application/msword</item>
+                    <item name="docx" xsi:type="string">application/vnd.openxmlformats-officedocument.wordprocessingml.document</item>
+                    <item name="docm" xsi:type="string">application/vnd.ms-word.document.macroEnabled.12</item>
+                    <item name="csv" xsi:type="string">text/plain</item>
+                    <item name="txt" xsi:type="string">text/plain</item>
+                    <item name="xml" xsi:type="string">application/xml</item>
+                    <item name="xls" xsi:type="string">application/vnd.ms-excel</item>
+                    <item name="xlsx" xsi:type="string">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</item>
+                    <item name="zip" xsi:type="string">application/zip</item>
+                    <item name="tar" xsi:type="string">application/x-tar</item>
+                    <item name="mp4" xsi:type="string">video/mp4</item>
+                    <item name="ogg" xsi:type="string">video/ogg</item>
+                    <item name="webm" xsi:type="string">video/webm</item>
+                </item>
+                <item name="image_allowed" xsi:type="array">
+                    <item name="jpg" xsi:type="string">image/jpg</item>
+                    <item name="jpeg" xsi:type="string">image/jpeg</item>
+                    <item name="png" xsi:type="string">image/png</item>
+                    <item name="gif" xsi:type="string">image/gif</item>
+                    <item name="pdf" xsi:type="string">application/pdf</item>
+                    <item name="doc" xsi:type="string">application/msword</item>
+                    <item name="docx" xsi:type="string">application/vnd.openxmlformats-officedocument.wordprocessingml.document</item>
+                    <item name="docm" xsi:type="string">application/vnd.ms-word.document.macroEnabled.12</item>
+                    <item name="csv" xsi:type="string">text/plain</item>
+                    <item name="txt" xsi:type="string">text/plain</item>
+                    <item name="xml" xsi:type="string">application/xml</item>
+                    <item name="xls" xsi:type="string">application/vnd.ms-excel</item>
+                    <item name="xlsx" xsi:type="string">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</item>
+                    <item name="zip" xsi:type="string">application/zip</item>
+                    <item name="tar" xsi:type="string">application/x-tar</item>
+                    <item name="mp4" xsi:type="string">video/mp4</item>
+                    <item name="ogg" xsi:type="string">video/ogg</item>
+                    <item name="webm" xsi:type="string">video/webm</item>
+                </item>
+                <item name="media_allowed" xsi:type="array">
+                    <item name="flv" xsi:type="string">video/x-flv</item>
+                    <item name="swf" xsi:type="string">application/x-shockwave-flash</item>
+                    <item name="avi" xsi:type="string">video/x-msvideo</item>
+                    <item name="mov" xsi:type="string">video/x-sgi-movie</item>
+                    <item name="rm" xsi:type="string">application/vnd.rn-realmedia</item>
+                    <item name="wmv" xsi:type="string">video/x-ms-wmv</item>
+                </item>
+            </argument>
+        </arguments>
 	</type>
 	<preference for="Magento\Framework\Image\Adapter\Gd2" type="Experius\WysiwygDownloads\Image\Adapter\Gd2" />
 </config>


### PR DESCRIPTION
Magento 2.2.5 adds a mime type check in the uploadFile method in [Magento/Cms/Model/Wysiwyg/Images/Storage.php](https://github.com/magento/magento2/blob/2.2.5/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php)

If the mime type check fails the upload is aborted, giving the error message ”File validation failed.”

The allowed mime types are defined in Magento/Cms/etc/di.xml

So, we need to add file and mime types we want to support to the allowed and image_allowed arrays in di.xml.