### PR TITLE
check for null param to avoid json_decode exception

### DIFF
--- a/Helper/Settings.php
+++ b/Helper/Settings.php
@@ -83,7 +83,13 @@ class Settings extends \Magento\Framework\App\Helper\AbstractHelper
 	public function getExtraFiletypes()
 	{
       $filetypes = array();
-      $settings = json_decode($this->getConfigValue(self::CONFIG_PATH_FILETYPES));
+      $settings = null;
+
+      $configFileTypes = $this->getConfigValue(self::CONFIG_PATH_FILETYPES);
+      if ($configFileTypes)
+      {
+          $settings = json_decode($configFileTypes);
+      }
       if ($settings) {
           foreach($settings as $setting){
               $filetypes[] =  $setting->extension;


### PR DESCRIPTION
In Magento CE 2.4.4 (PHP 8.1), system was crashing. json_decode was getting a null and throwing an exception. Added a couple of checks to ensure it doesn't crash in this case.