### PR TITLE
fix: SVG upload issues

### DIFF
--- a/Setup/Patch/Data/ProtectedExtensions.php
+++ b/Setup/Patch/Data/ProtectedExtensions.php
@@ -1,0 +1,107 @@
+<?php
+namespace Experius\WysiwygDownloads\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\MediaStorage\Model\File\Validator\NotProtectedExtension;
+
+class ProtectedExtensions implements DataPatchInterface, PatchRevertableInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        ScopeConfigInterface $scopeConfig,
+        WriterInterface $configWriter,
+        \Magento\Store\Model\StoreManagerInterface $storeManager
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->scopeConfig = $scopeConfig;
+        $this->configWriter = $configWriter;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply()
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+        $protectedExtensions = $this->getCurrentValue();
+        $protectedExtensions = array_diff($protectedExtensions, ['svg', 'svgz']);
+        $protectedExtensions = implode(',', $protectedExtensions);
+        $this->configWriter->save(
+            NotProtectedExtension::XML_PATH_PROTECTED_FILE_EXTENSIONS,
+            $protectedExtensions,
+            'default',
+            'default'
+        );
+        $this->moduleDataSetup->getConnection()->endSetup();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    public function revert()
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+        $protectedExtensions = $this->getCurrentValue();
+        $protectedExtensions = array_merge($protectedExtensions, ['svg', 'svgz']);
+        $this->configWriter->save(
+            NotProtectedExtension::XML_PATH_PROTECTED_FILE_EXTENSIONS,
+            implode(',', $protectedExtensions),
+            'default',
+            'default'
+        );
+        $this->moduleDataSetup->getConnection()->endSetup();
+    }
+
+    public function getCurrentValue() 
+    {
+        $configValue = $this->scopeConfig->getValue(
+            NotProtectedExtension::XML_PATH_PROTECTED_FILE_EXTENSIONS,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+        if(is_string($configValue)) {
+            return explode(',', $configValue);
+        }
+        return $configValue ?? [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -76,6 +76,7 @@
         <arguments>
             <argument name="imageExtensions" xsi:type="array">
                 <item name="pdf" xsi:type="string">pdf</item>
+                <item name="svg" xsi:type="string">svg</item>
             </argument>
         </arguments>
     </type>
@@ -83,6 +84,7 @@
         <arguments>
             <argument name="fileExtensions" xsi:type="array">
                 <item name="pdf" xsi:type="string">pdf</item>
+                <item name="svg" xsi:type="string">svg</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
While trying out this helpful Magento2 module, I found a small issue related to SVG files.
Don't know if its a known one or not, but I managed to fix it locally for myself and the projects I work on, so I decided to share here the changes that I did and hope that they are of use to other people as well.

# Issue that this PR is connected with

#32 

# Details about changes

* Added SVG as format to [di.xml](https://github.com/experius/Magento-2-Module-Experius-WysiwygDownloads/blob/b4be0ae90a11d353bf6110c33dcb3dbbc77945ed/etc/adminhtml/di.xml)
* Added `ProtectedExtensions` Data Patch meant to remove `svg` and `svgz` form the `general/file/protected_extension` config setting, while keeping the rest of the values.