### PR TITLE
[FEATURE][DOBO-786] Added bmp filetype, and Magento 2.4.7 compatibility

### DIFF
--- a/Helper/Settings.php
+++ b/Helper/Settings.php
@@ -129,6 +129,7 @@ class Settings extends AbstractHelper
             'mp4',
             'ogg',
             'webm',
+            'bmp'
         ];
 
         return array_merge($filetypes, $defaultFiletypes);

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-	<type name="Magento\Cms\Model\Wysiwyg\Images\Storage">
-		<plugin name="Experius_WysiwygDownloads_Plugin_Magento_Cms_Model_Wysiwyg_Images_Storage"
+    <type name="Magento\Cms\Model\Wysiwyg\Images\Storage">
+        <plugin name="Experius_WysiwygDownloads_Plugin_Magento_Cms_Model_Wysiwyg_Images_Storage"
                 type="Experius\WysiwygDownloads\Plugin\Magento\Cms\Model\Wysiwyg\Images\Storage"
                 sortOrder="10" />
         <arguments>
@@ -65,16 +65,25 @@
                 </item>
             </argument>
         </arguments>
-	</type>
+    </type>
     <type name="Magento\MediaGalleryUi\Ui\Component\Control\UploadAssets">
         <plugin name="Experius_WysiwygDownloads_Plugin_Magento_MediaGalleryUi_Ui_Component_Control_UploadAssets"
                 type="Experius\WysiwygDownloads\Plugin\Magento\MediaGalleryUi\Ui\Component\Control\UploadAssets"
                 sortOrder="10"/>
     </type>
-	<preference for="Magento\Framework\Image\Adapter\Gd2" type="Experius\WysiwygDownloads\Image\Adapter\Gd2" />
+    <type name="Magento\MediaGalleryUi\Ui\Component\Listing\Columns\Url">
+        <plugin name="Experius_WysiwygDownloads_Plugin_Magento_MediaGalleryUi_Ui_Component_Listing_Columns_Url"
+                type="Experius\WysiwygDownloads\Plugin\Magento\MediaGalleryUi\Ui\Component\Listing\Columns\Url"
+                sortOrder="10" disabled="false"/>
+    </type>
+    <preference for="Magento\Framework\Image\Adapter\Gd2" type="Experius\WysiwygDownloads\Image\Adapter\Gd2" />
     <type name="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation">
         <arguments>
             <argument name="imageExtensions" xsi:type="array">
+                <item name="jpg" xsi:type="string">jpg</item>
+                <item name="jpeg" xsi:type="string">jpeg</item>
+                <item name="gif" xsi:type="string">gif</item>
+                <item name="png" xsi:type="string">png</item>
                 <item name="pdf" xsi:type="string">pdf</item>
                 <item name="svg" xsi:type="string">svg</item>
             </argument>
@@ -83,6 +92,22 @@
     <type name="Magento\MediaGalleryRenditions\Model\Queue\FetchRenditionPathsBatches">
         <arguments>
             <argument name="fileExtensions" xsi:type="array">
+                <item name="jpg" xsi:type="string">jpg</item>
+                <item name="jpeg" xsi:type="string">jpeg</item>
+                <item name="gif" xsi:type="string">gif</item>
+                <item name="png" xsi:type="string">png</item>
+                <item name="pdf" xsi:type="string">pdf</item>
+                <item name="svg" xsi:type="string">svg</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\MediaGallerySynchronization\Model\FetchMediaStorageFileBatches">
+        <arguments>
+            <argument name="fileExtensions" xsi:type="array">
+                <item name="jpg" xsi:type="string">jpg</item>
+                <item name="jpeg" xsi:type="string">jpeg</item>
+                <item name="gif" xsi:type="string">gif</item>
+                <item name="png" xsi:type="string">png</item>
                 <item name="pdf" xsi:type="string">pdf</item>
                 <item name="svg" xsi:type="string">svg</item>
             </argument>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
                     <label>Extra Allowed Filetypes in the WYSIWYG-editor</label>
                 	<frontend_model>Experius\WysiwygDownloads\Block\Adminhtml\System\Config\Form\Field\Filetypes</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
-                    <comment><![CDATA[By default the following filetypes are available after installing this module 'doc','docm','docx','csv','xml','xls','xlsx','pdf','zip','tar']]></comment>
+                    <comment><![CDATA[By default the following filetypes are available after installing this module 'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'pdf', 'doc', 'docx', 'docm', 'odt', 'csv', 'txt', 'xml', 'xls', 'xlsx', 'ods', 'zip', 'tar', 'mp3', 'mp4', 'ogg', 'webm', 'bmp']]></comment>
 				</field>
 			</group>
 		</section>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Experius_WysiwygDownloads">
-		<sequence>
-			<module name="Magento_Cms"/>
-			<module name="Magento_Config"/>
-			<module name="Magento_Store"/>
-		</sequence>
-	</module>
+    <module name="Experius_WysiwygDownloads">
+        <sequence>
+            <module name="Magento_Cms"/>
+            <module name="Magento_Config"/>
+            <module name="Magento_Store"/>
+            <module name="MediaGalleryUi"/>
+            <module name="MediaGalleryIntegration"/>
+            <module name="MediaGallerySyncroization"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
Added bmp filetype, and Magento 2.4.7 compatibility
If you encounter an error during saving, its likely that the filetype isnt allowed yet.
You can add this locally in the storemanager under :
General -> Content manegent -> WYSIWYG Options -> Allowed fieltypes. 